### PR TITLE
fix parsing comment lines with a single ;

### DIFF
--- a/src/lex.js
+++ b/src/lex.js
@@ -53,7 +53,6 @@ module.exports = function(script) {
 
         /* ; comment */
         if (c === ';') {
-            i++;
             while (c !== '\n') {
                 i++;
                 if (i < len) {


### PR DESCRIPTION
lines with a single ; were commenting the next line

```
1 show.
;
2 show.
3 show.
```

only 1 and 3 would be shown before the fix
