### PR TITLE
Add copy

### DIFF
--- a/src/stdlib.js
+++ b/src/stdlib.js
@@ -19,6 +19,10 @@ function typeCheck(name, consumes, produces, func) {
             }
         }
 
+        if (typeof produces === "function") {
+            produces = produces(stack, scope);
+        }
+
         func(stack, scope);
 
         var resultHeight = stack.getHeight(),
@@ -73,6 +77,23 @@ defunTyped('swap', ['any', 'any'], ['any', 'any'], function (stack, scope) {
     var value2 = stack.pop();
     stack.push(value1);
     stack.push(value2);
+});
+defunTyped('copy', ['integer'], function (stack, scope) {
+    return Array.apply(null, new Array(stack.peek(0).getValue())).map(function () {
+        return 'any';
+    });
+}, function (stack, scope) {
+    var size = stack.pop();
+    if (size > stack.getHeight()) {
+        throw new Error('Trying to copy ' + size.getValue() + ' elements while stack height is ' + stack.getHeight());
+    }
+    var copy = [];
+    for (i = 0; i < size.getValue(); ++i) {
+        copy.push(stack.peek(i));
+    }
+    for (i = copy.length - 1; i >= 0; --i) {
+        stack.push(copy[i]);
+    }
 });
 
 // Language Spec § Functions § Flow Control

--- a/src/stdlib.js
+++ b/src/stdlib.js
@@ -84,7 +84,7 @@ defunTyped('copy', ['integer'], function (stack, scope) {
     });
 }, function (stack, scope) {
     var size = stack.pop();
-    if (size > stack.getHeight()) {
+    if (size.getValue() > stack.getHeight()) {
         throw new Error('Trying to copy ' + size.getValue() + ' elements while stack height is ' + stack.getHeight());
     }
     var copy = [];

--- a/src/stdlib.js
+++ b/src/stdlib.js
@@ -19,21 +19,24 @@ function typeCheck(name, consumes, produces, func) {
             }
         }
 
+        var produced = null;
         if (typeof produces === "function") {
-            produces = produces(stack, scope);
+            produced = produces(stack, scope);
+        } else {
+            produced = produces;
         }
 
         func(stack, scope);
 
         var resultHeight = stack.getHeight(),
-            expectedHeight = initialHeight - consumes.length + produces.length,
+            expectedHeight = initialHeight - consumes.length + produced.length,
             diff = expectedHeight - resultHeight;
         if (diff) {
-            throw new Error(name + " should consume " + consumes.length + " arguments and produce " + produces.length + " results, stack is " + Math.abs(diff) + " values too " + (diff > 0 ? "low" : "high"));
+            throw new Error(name + " should consume " + consumes.length + " arguments and produce " + produced.length + " results, stack is " + Math.abs(diff) + " values too " + (diff > 0 ? "low" : "high"));
         }
-        for (var i = 0; i < produces.length; i++) {
-            var actualType = stack.peek(produces.length - 1 - i).getType(),
-                expectedType = produces[i];
+        for (var i = 0; i < produced.length; i++) {
+            var actualType = stack.peek(produced.length - 1 - i).getType(),
+                expectedType = produced[i];
             if (expectedType !== 'any' && actualType !== expectedType) {
                 throw new Error("Result " + (i + 1) + " of " + name + " should be of the type " + expectedType + ", " + actualType + " produced");
             }


### PR DESCRIPTION
As described in http://www.ugrad.math.ubc.ca/Flat/stack-ref.html#PScopy

> obn ... ob1 n copy obn ... ob1 obn ... ob1 This operator adds a copy of the top n objects on the stack.

For example, after executing this:

``` firth
10 20 2 copy.
```

The stack would contain: `10 20 10 20`

I had to make some changes in `typeCheck` so it would allow a callback, because I can't retrieve how much values of `any` it would return after executing.
